### PR TITLE
[Enterprise] Work both the pusher-live and pusher queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-live: bundle exec je sidekiq -c 25 -r ./lib/travis/live/pusher.rb -q pusher-live
+live: bundle exec je sidekiq -c 25 -r ./lib/travis/live/pusher.rb -q pusher-live -q pusher


### PR DESCRIPTION
An Enterprise customer noticed the that `pusher` sidekiq queue was growing and never going down. Found that this code in `travis-core`: https://github.com/travis-ci/travis-core/blob/fd905d451087627e1d7320585b10c5bf75d6ad40/lib/travis/addons/pusher/event_handler.rb#L36-L43 was the source of the issue as Feature Flags aren't a thing in Enterprise. 

The long term fix is to remove this if statement as it's no longer needed. The immediate fix for Enterprise 2.0 is to have `travis-live` work both queues. 