### PR TITLE
Send messages to user channels if user_ids are supplied

### DIFF
--- a/lib/travis/live/pusher/task.rb
+++ b/lib/travis/live/pusher/task.rb
@@ -25,12 +25,22 @@ module Travis
           params[:event]
         end
 
+        def user_ids
+          params[:user_ids]
+        end
+
         def client_event
           @client_event ||= (event =~ /job:.*/ ? event.gsub(/(test|configure):/, '') : event)
         end
 
         def channels
-          channels = ["repo-#{repo_id}"]
+          channels = []
+          if user_ids
+            user_channels = user_ids.map { |id| "user-#{id}" }
+            channels.push *user_channels
+          else
+            channels << "repo-#{repo_id}"
+          end
           channels << "common" if public_channels? && !Travis.config.pusher.disable_common_channel?
           channels.map { |channel| [channel_prefix, channel].compact.join('-') }
         end

--- a/spec/pusher/task_spec.rb
+++ b/spec/pusher/task_spec.rb
@@ -34,6 +34,17 @@ describe Travis::Live::Pusher::Task do
       task.channels.should == ["repo-16594", "common"]
     end
 
+    context 'when user_ids were sent' do
+      before do
+        params.merge! user_ids: [1, 3]
+      end
+
+      it 'sends to user channels instead of repo channels' do
+        task = Travis::Live::Pusher::Task.new(payload, params)
+        task.channels.should == ["user-1", "user-3", "common"]
+      end
+    end
+
     it 'disables common channel with disable_common_channel setting' do
       begin
         Travis.config.pusher.disable_common_channel = true


### PR DESCRIPTION
If we get `user_ids` in params, we can send messages to user based
channels. This allows us to enable per user channels only when a sidekiq task is sent with `user_ids`