### PR TITLE
Send a message to multiple channels at once

### DIFF
--- a/lib/travis/live/pusher/task.rb
+++ b/lib/travis/live/pusher/task.rb
@@ -48,11 +48,11 @@ module Travis
         private
 
           def process
-            channels.each { |channel| trigger(channel, payload) }
+            trigger(channels, payload)
           end
 
-          def trigger(channel, payload)
-            Travis.pusher[channel].trigger(client_event, payload)
+          def trigger(channels, payload)
+            Travis.pusher.trigger(channels, client_event, payload)
           rescue ::Pusher::Error => e
             Travis.logger.error("[addons:pusher] Could not send event due to Pusher::Error: #{e.message}, event=#{client_event}, payload: #{part.inspect}")
             raise

--- a/spec/pusher/task_spec.rb
+++ b/spec/pusher/task_spec.rb
@@ -57,8 +57,7 @@ describe Travis::Live::Pusher::Task do
 
     it 'triggers a pusher event with the correct payload' do
       task = Travis::Live::Pusher::Task.new(payload, params)
-      task.expects(:trigger).with("repo-16594", payload.deep_symbolize_keys)
-      task.expects(:trigger).with("common", payload.deep_symbolize_keys)
+      task.expects(:trigger).with(["repo-16594", "common"], payload.deep_symbolize_keys)
       task.run
     end
   end


### PR DESCRIPTION
That way we will make only one call to Pusher to send a message to
N channels, instead of making N calls.