### PR TITLE
Send message to a repo channel if repository is public

### DIFF
--- a/lib/travis/live/pusher/task.rb
+++ b/lib/travis/live/pusher/task.rb
@@ -38,7 +38,8 @@ module Travis
           if user_ids
             user_channels = user_ids.map { |id| "user-#{id}" }
             channels.push *user_channels
-          else
+          end
+          if repository_public? || !user_ids
             channels << "repo-#{repo_id}"
           end
           channels << "common" if public_channels? && !Travis.config.pusher.disable_common_channel?
@@ -85,6 +86,10 @@ module Travis
 
           def repository_private?
             payload.key?(:repository) ? payload[:repository][:private] : payload[:repository_private]
+          end
+
+          def repository_public?
+            !repository_private?
           end
 
           def timeout(options = { after: 60 }, &block)

--- a/spec/pusher/task_spec.rb
+++ b/spec/pusher/task_spec.rb
@@ -39,9 +39,15 @@ describe Travis::Live::Pusher::Task do
         params.merge! user_ids: [1, 3]
       end
 
-      it 'sends to user channels instead of repo channels' do
+      it 'sends to user channels as well' do
         task = Travis::Live::Pusher::Task.new(payload, params)
-        task.channels.should == ["user-1", "user-3", "common"]
+        task.channels.should == ["user-1", "user-3", "repo-16594", "common"]
+      end
+
+      it 'does not send to a repo channel when repository is private' do
+        payload['repository_private'] = true
+        task = Travis::Live::Pusher::Task.new(payload, params)
+        task.channels.should == ["private-user-1", "private-user-3"]
       end
     end
 


### PR DESCRIPTION
On travis-ci.org users can view any public repo and if they do, need to
provide live updates to them as well.