### PR TITLE
Simplify channels logic

### DIFF
--- a/lib/travis/live/pusher/task.rb
+++ b/lib/travis/live/pusher/task.rb
@@ -34,14 +34,13 @@ module Travis
         end
 
         def channels
-          channels = []
-          user_channels = user_ids.map { |id| "user-#{id}" }
-          channels.push *user_channels
+          channels = user_ids.map { |id| "private-user-#{id}" }
 
-          if repository_public?
+          if public_channels?
             channels << "repo-#{repo_id}"
           end
-          channels.map { |channel| [channel_prefix, channel].compact.join('-') }
+
+          channels
         end
 
         private
@@ -84,10 +83,6 @@ module Travis
 
           def repository_private?
             payload.key?(:repository) ? payload[:repository][:private] : payload[:repository_private]
-          end
-
-          def repository_public?
-            !repository_private?
           end
 
           def timeout(options = { after: 60 }, &block)

--- a/spec/pusher/task_spec.rb
+++ b/spec/pusher/task_spec.rb
@@ -39,9 +39,20 @@ describe Travis::Live::Pusher::Task do
         params.merge! user_ids: [1, 3]
       end
 
+      context 'when config.pusher.secure? is set' do
+        before do
+          Travis.config.pusher.secure = true
+        end
+
+        it 'doesn\'t send to public channels' do
+          task = Travis::Live::Pusher::Task.new(payload, params)
+          task.channels.should == ["private-user-1", "private-user-3"]
+        end
+      end
+
       it 'sends to user channels as well' do
         task = Travis::Live::Pusher::Task.new(payload, params)
-        task.channels.should == ["user-1", "user-3", "repo-16594"]
+        task.channels.should == ["private-user-1", "private-user-3", "repo-16594"]
       end
 
       it 'does not send to a repo channel when repository is private' do


### PR DESCRIPTION
API uses only private user channels at this point, so we can safely
always send only to private user channels. Additionaly, sending updates
to public repos should be done only when a repo is public and when we're
not forcing private channels.

This simplifies the code and also it simplifies further work on merging
both platforms.