### PR TITLE
Set Sentry using travis-exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ ruby '2.4.2'
 
 gem 'sidekiq-pro', source: 'https://gems.contribsys.com'
 
-gem 'activesupport',    '~> 4.2.5'
-gem 'travis-support',   github: 'travis-ci/travis-support'
-gem 'travis-config',    '~> 1.0.3'
+gem 'activesupport',     '~> 4.2.5'
+gem 'travis-config',     '~> 1.0.3'
+gem 'travis-exceptions', github: 'travis-ci/travis-exceptions'
+gem 'travis-support',    github: 'travis-ci/travis-support'
 
 gem 'redis-namespace'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
     rollout (1.1.0)
 
 GIT
+  remote: git://github.com/travis-ci/travis-exceptions.git
+  revision: ab236981f810b820bc3ebfaf33f317bbaa9b3465
+  specs:
+    travis-exceptions (0.0.2)
+      sentry-raven
+
+GIT
   remote: git://github.com/travis-ci/travis-support.git
   revision: 113cff17fe383bb72fcfae3a97a8ce98c228342f
   specs:
@@ -146,6 +153,7 @@ DEPENDENCIES
   sentry-raven
   sidekiq-pro!
   travis-config (~> 1.0.3)
+  travis-exceptions!
   travis-support!
   webmock (~> 1.8.0)
 

--- a/lib/travis/live/pusher.rb
+++ b/lib/travis/live/pusher.rb
@@ -1,13 +1,12 @@
 $:.unshift(File.expand_path('../..', File.dirname(__FILE__)))
 
-require 'bundler/setup'
 require 'metriks/librato_metrics_reporter'
-require 'travis/live/error_handler'
 require 'travis/live/config'
 require 'travis/live/pusher/worker'
 require 'travis/live/middleware/metriks'
 require 'travis/live/middleware/logging'
-require 'travis/support/exceptions'
+require 'travis/exceptions'
+require 'travis/exceptions/sidekiq'
 require 'travis/support/logging'
 require 'travis/support/logger'
 require 'travis/support/metrics'
@@ -39,16 +38,6 @@ end
 
 $stdout.sync = true
 
-if Travis.config.sentry.dsn
-  require 'raven'
-  Raven.configure do |config|
-    config.dsn = Travis.config.sentry.dsn
-
-    config.current_environment = Travis.env
-    config.environments = ["staging", "production"]
-  end
-end
-
 Sidekiq.configure_server do |config|
   pro = ::Sidekiq::NAME == 'Sidekiq Pro'
 
@@ -65,16 +54,14 @@ Sidekiq.configure_server do |config|
     chain.add Travis::Live::Middleware::Metriks
     chain.add Travis::Live::Middleware::Logging
 
-    if defined?(::Raven::Sidekiq)
-      chain.remove(::Raven::Sidekiq)
+    if Travis.config.sentry
+      chain.add Travis::Exceptions::Sidekiq
     end
-
-    chain.add(Travis::Live::ErrorHandler)
   end
 end
 
 if Travis.config.sentry
-  Travis::Exceptions::Reporter.start
+  Travis::Exceptions.setup(Travis.config, Travis.config.env, Travis.logger)
 end
 
 Travis::Metrics.setup(Travis.config.metrics.reporter)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ RSpec.configure do |c|
   c.before(:each) { Time.now.utc.tap { | now| Time.stubs(:now).returns(now) } }
 end
 
-require 'travis/support'
 require 'travis/support/testing/webmock'
 require 'travis/live/pusher'
 


### PR DESCRIPTION
This commit sets Sentry support (as it was broken till now) using
travis-exceptions gem