### PR TITLE
Send only the object id if payload is too big

### DIFF
--- a/spec/pusher/task_spec.rb
+++ b/spec/pusher/task_spec.rb
@@ -34,6 +34,31 @@ describe Travis::Live::Pusher::Task do
       task.channels.should == ["repo-16594"]
     end
 
+    it 'sends only an id if the job  payload is too big' do
+      payload['commit']['message'] = 'a' * 10240
+      task = Travis::Live::Pusher::Task.new(payload, params)
+      task.expects(:trigger).with(["repo-16594"], { id: 430969, build_id: 430967, _no_full_payload: true })
+      task.run
+    end
+
+    it 'sends only an id if the job  payload is too big' do
+      payload = {
+        "build" => {
+          "id" => 100
+        },
+        "commit" => {
+          "message" => "a" * 10240
+        },
+        "repository" => {
+          "id" => 1
+        }
+      }
+      params = { "event" => "build:started" }
+      task = Travis::Live::Pusher::Task.new(payload, params)
+      task.expects(:trigger).with(["repo-1"], { build: { id: 100 }, _no_full_payload: true })
+      task.run
+    end
+
     context 'when user_ids were sent' do
       before do
         params.merge! user_ids: [1, 3]


### PR DESCRIPTION
Pusher may only send messages up to 10kB, so when a payload is too big,
it will error out. This commit checks the length of the message before
sending and sends only the id when the message is too big.

This will need to wait for a corresponding change in travis-web, which would download the record by id if there's no data for it.